### PR TITLE
US_003 - Edit todo name

### DIFF
--- a/backend/cranki/src/main/java/ca/mcgill/cranki/controller/TodoItemController.java
+++ b/backend/cranki/src/main/java/ca/mcgill/cranki/controller/TodoItemController.java
@@ -40,4 +40,22 @@ public class TodoItemController {
         return new ResponseEntity<>(todoItemDto, HttpStatus.OK);
     }
 
+    @PutMapping( value = { "/todoItem/updateName", "todoItem/updateName/" })
+    public ResponseEntity<String> editTodoName(
+            @RequestParam(name = "id") int id,
+            @RequestParam(name = "name") String name) {
+        if (name.trim().isEmpty()) {
+            return new ResponseEntity<>("Name cannot be empty", HttpStatus.BAD_REQUEST);
+        }
+
+        var item_option = todoItemRepository.findById(id);
+        if (item_option.isEmpty()) {
+            return new ResponseEntity<>("Todo is not found", HttpStatus.NOT_FOUND);
+        }
+        var item = item_option.get();
+        item.setName(name.trim());
+        todoItemRepository.save(item);
+
+        return ResponseEntity.ok("Todo item name updated successfully");
+    }
 }

--- a/backend/cranki/src/test/java/ca/mcgill/cranki/features/editTodoNameStepDefs.java
+++ b/backend/cranki/src/test/java/ca/mcgill/cranki/features/editTodoNameStepDefs.java
@@ -1,0 +1,77 @@
+package ca.mcgill.cranki.features;
+
+import ca.mcgill.cranki.controller.TodoItemController;
+import ca.mcgill.cranki.model.TodoItem;
+import ca.mcgill.cranki.repository.TodoItemRepository;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.Assert.assertEquals;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class editTodoNameStepDefs {
+
+    @Autowired
+    private TodoItemRepository todoItemRepository;
+
+    @Autowired
+    private TodoItemController todoItemController;
+
+    private ResponseEntity<String> controllerResponse;
+    private TodoItem testTodoItem;
+
+    private void clearDatabase() {
+        todoItemRepository.deleteAll();
+    }
+
+    @Given("the following todo exists")
+    public void theFollowingTodoExists(io.cucumber.datatable.DataTable dataTable) {
+        clearDatabase();
+        var rows = dataTable.asMaps();
+        for (var row : rows) {
+            testTodoItem = new TodoItem();
+            testTodoItem.setName(row.get("name"));
+            testTodoItem = todoItemRepository.save(testTodoItem);
+        }
+    }
+
+    @When("I edit the todo item name to {string}")
+    public void iEditTheTodoItemNameTo(String newName) {
+        controllerResponse = todoItemController.editTodoName(testTodoItem.getId(), newName);
+    }
+
+    @Then("the todo item name should be {string}")
+    public void theTodoItemNameShouldBe(String expectedName) {
+        assertEquals(200, controllerResponse.getStatusCode().value());
+        assertEquals("Todo item name updated successfully", controllerResponse.getBody());
+
+        TodoItem updated = todoItemRepository.findById(testTodoItem.getId()).get();
+        assertEquals(expectedName, updated.getName());
+    }
+
+    @When("I try to edit a non-existent todo item with id {string}")
+    public void iTryToEditANonExistentTodoItem(String id) {
+        controllerResponse = todoItemController.editTodoName(Integer.parseInt(id), "New Name");
+    }
+    
+    @Then("I should receive a not found error")
+    public void iShouldReceiveANotFoundError() {
+        assertEquals(404, controllerResponse.getStatusCode().value());
+        assertEquals("Todo is not found", controllerResponse.getBody());
+    }
+
+    @When("I try to edit the todo item name to empty")
+    public void iTryToEditTheTodoItemNameToEmpty() {
+        controllerResponse = todoItemController.editTodoName(testTodoItem.getId(), "   ");
+    }
+
+    @Then("I should receive an empty name error")
+    public void iShouldReceiveAnEmptyNameError() {
+        assertEquals(400, controllerResponse.getStatusCode().value());
+        assertEquals("Name cannot be empty", controllerResponse.getBody());
+    }
+}

--- a/backend/cranki/src/test/java/resources/editTodoName.feature
+++ b/backend/cranki/src/test/java/resources/editTodoName.feature
@@ -1,0 +1,21 @@
+Feature: Edit Todo
+    As a User 
+    I would like to edit a todo item
+    So that I can update its name
+
+Background:
+    Given the following todo exists
+        | id | name          |
+        | 1  | Buy Groceries |
+
+Scenario: User edits the name of the todo (Normal Flow)
+    When I edit the todo item name to "Buy Milk"
+    Then the todo item name should be "Buy Milk"
+
+Scenario: User attempts to edit with empty name (Error Flow)
+    When I try to edit the todo item name to empty
+    Then I should receive an empty name error
+
+Scenario: User attempts to edit non-existent todo (Error Flow)
+    When I try to edit a non-existent todo item with id "999"
+    Then I should receive a not found error

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+package-lock.*
+package-lock.json

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-toast": "^1.2.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.453.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+
 import { useEffect, useState } from "react";
 import {
   Table,
@@ -174,7 +175,6 @@ function App() {
           </div>
         </div>
       </div>
-    </div>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,181 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useEffect, useState } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./components/ui/table";
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+// Define the shape of a single todo item
+interface TodoItem {
+  id: number;
+  name: string;
+  status: "TODO" | "DONE" | "IN_PROGRESS";
 }
 
-export default App
+function App() {
+  // State for a single todo item since we're only fetching one todo for now
+  const [todo, setTodo] = useState<TodoItem | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedName, setEditedName] = useState("");
+
+  useEffect(() => {
+    // Fetch a single todo item with ID 1
+    // Note: In the future, this will be expanded to fetch multiple todos
+    const fetchTodo = async () => {
+      try {
+        // Currently using /todoItem/1 endpoint since the API for multiple todos is not available yet
+        const response = await fetch("http://localhost:8080/todoItem/1");
+        if (!response.ok) throw new Error("Failed to fetch todo");
+        const data = await response.json();
+        setTodo(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to fetch todo");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTodo();
+  }, []);
+
+  // Handle name edit submission
+  const handleNameSubmit = async () => {
+    if (!todo) return;
+
+    try {
+      const response = await fetch(
+        `http://localhost:8080/todoItem/updateName?id=${todo.id}&name=${editedName}`,
+        {
+          method: "PUT",
+        }
+      );
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText);
+      }
+
+      // Update local state with new name
+      setTodo((prev) => (prev ? { ...prev, name: editedName } : null));
+      setIsEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update name");
+    }
+  };
+
+  // Handle key press events for the edit input
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleNameSubmit();
+    } else if (e.key === "Escape") {
+      setIsEditing(false);
+      setEditedName(todo?.name || "");
+    }
+  };
+
+  // Loading, error, and empty states for single todo
+  if (isLoading)
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-pulse text-lg">Loading...</div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-red-500">Error: {error}</div>
+      </div>
+    );
+
+  if (!todo)
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-gray-500">No todo found</div>
+      </div>
+    );
+
+  // Render a single todo item in a table format
+  // This will be updated to show multiple todos when the API is available
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="container mx-auto py-10 px-4 max-w-4xl">
+        <div className="bg-white rounded-lg shadow-lg p-6">
+          <h1 className="text-3xl font-bold mb-6 text-center text-gray-800">
+            Todo Item
+          </h1>
+          <div className="flex justify-center">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-gray-50">
+                  <TableHead className="text-center">ID</TableHead>
+                  <TableHead className="text-center">Name</TableHead>
+                  <TableHead className="text-center">Status</TableHead>
+                  <TableHead className="text-center">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <TableRow>
+                  <TableCell className="text-center">{todo.id}</TableCell>
+                  <TableCell
+                    className="text-center cursor-pointer hover:bg-gray-50"
+                    onClick={() => {
+                      if (!isEditing) {
+                        setIsEditing(true);
+                        setEditedName(todo.name);
+                      }
+                    }}
+                  >
+                    {isEditing ? (
+                      <input
+                        type="text"
+                        value={editedName}
+                        onChange={(e) => setEditedName(e.target.value)}
+                        onKeyDown={handleKeyPress}
+                        onBlur={handleNameSubmit}
+                        className="w-full px-2 py-1 text-center border rounded"
+                        autoFocus
+                      />
+                    ) : (
+                      <span className="hover:text-blue-600">{todo.name}</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <span
+                      className={`px-3 py-1 rounded-full text-sm ${
+                        todo.status === "DONE"
+                          ? "bg-green-100 text-green-800"
+                          : todo.status === "IN_PROGRESS"
+                          ? "bg-yellow-100 text-yellow-800"
+                          : "bg-gray-100 text-gray-800"
+                      }`}
+                    >
+                      {todo.status}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <button
+                      onClick={() => {
+                        /* TODO: Implement status update */
+                      }}
+                      className="px-4 py-2 bg-green-500 text-white rounded-md hover:bg-green-600 transition-colors"
+                    >
+                      Toggle Status
+                    </button>
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/TodoItem.tsx
+++ b/frontend/src/TodoItem.tsx
@@ -1,0 +1,24 @@
+// TodoItem.tsx
+import React from "react";
+
+interface TodoItemProps {
+  id: number;
+  title: string;
+  completed: boolean;
+  onComplete: (id: number) => void;
+}
+
+const TodoItem: React.FC<TodoItemProps> = ({ id, title, completed, onComplete }) => {
+  const handleCheckboxChange = () => {
+    onComplete(id);
+  };
+
+  return (
+    <div className={`todo-item ${completed ? "done" : ""}`}>
+      <input type="checkbox" checked={completed} onChange={handleCheckboxChange} />
+      <span className="todo-title">{title}</span>
+    </div>
+  );
+};
+
+export default TodoItem;

--- a/frontend/src/TodoList.tsx
+++ b/frontend/src/TodoList.tsx
@@ -1,0 +1,54 @@
+// TodoList.tsx
+import React, { useEffect, useState } from "react";
+import TodoItem from "./TodoItem";
+
+interface Todo {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+const TodoList: React.FC = () => {
+  const [todos, setTodos] = useState<Todo[]>([]);
+
+  // Fetch the initial list of todos
+  useEffect(() => {
+    fetch("/api/todoitems")
+      .then((res) => res.json())
+      .then((data) => setTodos(data));
+  }, []);
+
+  // Function to mark a task as done
+  const markAsDone = async (id: number) => {
+    try {
+      const response = await fetch(`/api/todoitems/${id}/done`, {
+        method: "PUT",
+      });
+
+      if (response.ok) {
+        // Update the state with the completed task
+        setTodos((prevTodos) =>
+          prevTodos.map((todo) => (todo.id === id ? { ...todo, completed: true } : todo))
+        );
+      }
+    } catch (error) {
+      console.error("Error marking todo as done:", error);
+    }
+  };
+
+  return (
+    <div className="todo-list">
+      {todos.map((todo) => (
+        <TodoItem
+          key={todo.id}
+          id={todo.id}
+          title={todo.title}
+          completed={todo.completed}
+          onComplete={markAsDone}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default TodoList;

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,88 @@
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto flex justify-center">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm text-center", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead
+    ref={ref}
+    className={cn("[&_tr]:border-b text-center", className)}
+    {...props}
+  />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0 text-center", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted text-center",
+      className
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-center align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-4 align-middle text-center [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,21 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ["class"],
+  content: [
+    "./pages/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./app/**/*.{ts,tsx}",
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
This PR includes the backend for feature US_003

The API does the following:
Validates that name is not empty and checks if the id exists.
Returns 400 Bad Request if name is empty, 404 Not Found if the item is missing, and 200 OK if the update is successful.

Testing Instructions:

Valid Update:
curl -X PUT "http://localhost:8080/todoItem/updateName?id=1&name=newName"
Expected: 200 OK with success message.

Empty Name:
curl -X PUT "http://localhost:8080/todoItem/updateName?id=1&name="
Expected: 400 Bad Request with "Name cannot be empty."

Non-Existent ID:
curl -X PUT "http://localhost:8080/todoItem/updateName?id=999&name=newName"
Expected: 404 Not Found with "Todo is not found."


UI:
We also setup a basic UI which includes a table with todo items. For the moment, the API fetches a specific todo (id: 1) because fetchAllTodos is not implemented. The editing functionality should work on the UI too.

To test the UI, run the following commands:
npm install
npm run dev

Try it out !